### PR TITLE
Fatal error when users attempt to generate a QR code

### DIFF
--- a/conf/environment.php
+++ b/conf/environment.php
@@ -12,5 +12,5 @@ define('DATABASE_USER', "__DB_USER__");
 define('DATABASE_PASSWORD', "__DB_PWD__");
 define('DATABASE_PREFIX', "qr_"); // This must have a trailing underscore. Example: qr_
 define('DATABASE_CHARSET', "utf8");
-
+define("QRCODE_GENERATOR", "external-api.qrserver.com");
 ?>

--- a/doc/POST_INSTALL.md
+++ b/doc/POST_INSTALL.md
@@ -1,3 +1,5 @@
 Default credentials:
 username: superadmin
 password: superadmin
+A **superadmin** account can only create and manage users, and manage existing QR codes.
+An **admin** user account must be created in order to **generate new QR codes**.

--- a/doc/POST_INSTALL_fr.md
+++ b/doc/POST_INSTALL_fr.md
@@ -1,3 +1,6 @@
 Identifiants par défaut :
 username: superadmin
 password: superadmin
+
+Un compte de type superadmin peut seulement créer et gérer les utilisateurs et gérer les qrcodes créés.
+Un compte utilisateur de type admin doit être créé pour pouvoir créer des qrcodes. 

--- a/doc/POST_INSTALL_fr.md
+++ b/doc/POST_INSTALL_fr.md
@@ -2,5 +2,5 @@ Identifiants par défaut :
 username: superadmin
 password: superadmin
 
-Un compte de type superadmin peut seulement créer et gérer les utilisateurs et gérer les qrcodes créés.
-Un compte utilisateur de type admin doit être créé pour pouvoir créer des qrcodes. 
+Un compte de type **superadmin** peut seulement créer et gérer les utilisateurs et gérer les qrcodes créés.
+Un compte utilisateur de type **admin** doit être créé pour pouvoir **créer des qrcodes**. 


### PR DESCRIPTION
## Problem

- On a fresh installation of the application, an environment constant is missing, causing a fatal error when users attempt to generate a QR code: 
Note

> Fatal error: Uncaught Error: Undefined constant "QRCODE_GENERATOR" in /var/www/dynamicqrcode/src/lib/DynamicQrcode/DynamicQrcode.php:4 Stack trace: #0 /var/www/dynamicqrcode/src/dynamic_qrcode.php(5): require_once() https://github.com/YunoHost-Apps/dynamicqrcode_ynh/pull/1 {main} thrown in /var/www/dynamicqrcode/src/lib/DynamicQrcode/DynamicQrcode.php on line 4

- QR code generation is not available for the “superadmin” user (bug?)

## Solution

- added missing variable `QRCODE_GENERATOR`
- warning displayed about qrcode generation

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)